### PR TITLE
Add work item relationship management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the Azure DevOps MCP Server will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2025-01-18
+
+### Added
+- **Work Item Relationship Management** - 4 new tools for managing relationships between work items:
+  - `add_work_item_relation` - Add relationships between work items (Parent/Child, Related, Dependencies, etc.)
+  - `remove_work_item_relation` - Remove relationships between work items
+  - `get_work_item_relations` - View all relationships for a work item with friendly categorization
+  - `list_relation_types` - List all available relation types in Azure DevOps
+- User-friendly relation type mapping (e.g., use "Parent" instead of "System.LinkTypes.Hierarchy-Reverse")
+- Support for multiple target IDs in relation operations
+- Categorized relation type listing for better organization
+- Comprehensive error handling and helpful hints for relation operations
+
+### Features
+- Build work item hierarchies (Epic → Feature → User Story → Task)
+- Track dependencies between work items
+- Mark duplicate work items
+- Connect test cases to requirements
+- Support for custom relationship types
+- Friendly relation names with automatic mapping to Azure DevOps internal types
+
+### Technical Details
+- Added `src/types/relations.ts` for relation type definitions
+- Added `src/tools/relations.ts` for relation tool definitions
+- Added `src/handlers/relations.ts` for relation operation handlers
+- Total tool count increased from 26 to 30 tools
+
 ## [2.1.0] - 2025-01-16
 
 ### Fixed
@@ -115,14 +142,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Planned Features
 - Batch operations for multiple work items
-- Work item relationships and links management
-- Sprint and iteration support
 - Board and backlog operations
 - Advanced filtering and search capabilities
 - Export functionality (CSV, JSON)
 - Work item templates
 - Custom field support
 - Webhook integration for real-time updates
+- Wiki page management
+- Pipeline execution and monitoring
 
 ---
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -170,6 +170,123 @@ az devops configure --defaults organization= project=
 }
 ```
 
+### Work Item Relationship Examples
+
+```javascript
+// Add parent-child relationship
+{
+  "tool": "add_work_item_relation",
+  "arguments": {
+    "id": 123,  // Child work item
+    "relation_type": "Parent",
+    "target_id": 100  // Parent work item
+  }
+}
+
+// Add multiple children to a parent
+{
+  "tool": "add_work_item_relation",
+  "arguments": {
+    "id": 100,  // Parent work item
+    "relation_type": "Child",
+    "target_id": [123, 124, 125]  // Multiple children
+  }
+}
+
+// Create dependency relationship
+{
+  "tool": "add_work_item_relation",
+  "arguments": {
+    "id": 200,
+    "relation_type": "Predecessor",
+    "target_id": 199  // Task 200 depends on task 199
+  }
+}
+
+// Mark as duplicate
+{
+  "tool": "add_work_item_relation",
+  "arguments": {
+    "id": 301,
+    "relation_type": "Duplicate",
+    "target_id": 300
+  }
+}
+
+// Add related items
+{
+  "tool": "add_work_item_relation",
+  "arguments": {
+    "id": 400,
+    "relation_type": "Related",
+    "target_id": 401
+  }
+}
+
+// Get all relationships for a work item
+{
+  "tool": "get_work_item_relations",
+  "arguments": {
+    "id": 100
+  }
+}
+
+// Remove a relationship
+{
+  "tool": "remove_work_item_relation",
+  "arguments": {
+    "id": 100,
+    "relation_type": "Child",
+    "target_id": 123
+  }
+}
+
+// List all available relation types
+{
+  "tool": "list_relation_types",
+  "arguments": {}
+}
+```
+
+### Iteration/Sprint Examples
+
+```javascript
+// List all iterations in a project
+{
+  "tool": "list_iterations",
+  "arguments": {
+    "project": "MyProject"
+  }
+}
+
+// Get current sprint
+{
+  "tool": "get_current_iteration",
+  "arguments": {
+    "project": "MyProject"
+  }
+}
+
+// Move work item to different sprint
+{
+  "tool": "move_to_iteration",
+  "arguments": {
+    "id": 123,
+    "iteration": "Sprint 5",
+    "project": "MyProject"
+  }
+}
+
+// Get all work items in a sprint
+{
+  "tool": "get_iteration_work_items",
+  "arguments": {
+    "project": "MyProject",
+    "iteration": "Sprint 4"
+  }
+}
+```
+
 ## Troubleshooting
 
 ### Common Issues and Solutions

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Model Context Protocol (MCP) server that enables Claude to interact with Azure DevOps work items, projects, and boards directly through natural language.
 
-**Version 2.1.0** - Now with 26 working tools (query management tools removed for reliability)
+**Version 2.2.0** - Now with 30 tools including work item relationship management
 
 ## 🎯 Features
 
@@ -33,6 +33,14 @@ A Model Context Protocol (MCP) server that enables Claude to interact with Azure
   - View items organized by state
   - Include recently completed items
   - Use smart query shortcuts (`my-items`, `my-bugs`, `my-tasks`, `recent`)
+
+- **Work Item Relationships** 🆕
+  - Add relationships between work items (Parent/Child, Related, Dependencies)
+  - Remove relationships between work items
+  - View all relationships for a work item
+  - List available relationship types
+  - Build work item hierarchies (Epic → Feature → Story → Task)
+  - Track dependencies and mark duplicates
 
 ## 📋 Prerequisites
 
@@ -146,13 +154,14 @@ You must configure your Azure DevOps organization in one of two ways:
 az devops configure --defaults organization=https://dev.azure.com/YOUR_ORG
 ```
 
-## 🛠️ Available Tools (26 Total)
+## 🛠️ Available Tools (30 Total)
 
 **Categories:**
 - **Work Items** (6 tools): Query, create, update, comment on work items
 - **Discovery** (9 tools): Explore fields, types, states, and relationships
 - **Projects** (6 tools): Manage projects, teams, repos, and pipelines
 - **Iterations** (5 tools): Handle sprints and iteration planning
+- **Relations** (4 tools): Manage work item relationships and hierarchies
 
 > **Note:** Query management tools have been removed in v2.1.0 for improved reliability
 
@@ -252,10 +261,41 @@ Get detailed information about an iteration including work items grouped by type
 - `project` (required): Project name
 - `iteration` (required): Iteration name
 
+### Work Item Relationship Tools 🆕
+
+### `add_work_item_relation`
+Add a relationship between work items.
+
+**Parameters:**
+- `id` (required): Source work item ID
+- `relation_type` (required): Relationship type (e.g., "Parent", "Child", "Related", "Predecessor", "Successor", "Duplicate")
+- `target_id` (optional): Target work item ID(s) - can be single ID or array
+- `target_url` (optional): URL to target work item (alternative to target_id)
+
+### `remove_work_item_relation`
+Remove a relationship between work items.
+
+**Parameters:**
+- `id` (required): Source work item ID
+- `relation_type` (required): Relationship type to remove
+- `target_id` (required): Target work item ID(s) to unlink
+
+### `get_work_item_relations`
+Show all relationships for a work item with friendly categorization.
+
+**Parameters:**
+- `id` (required): Work item ID
+
+### `list_relation_types`
+List all available work item relation types in Azure DevOps.
+
+**Parameters:** None
+
 ## 💬 Usage Examples
 
 Once configured, you can ask Claude:
 
+**Work Item Management:**
 - "List all my Azure DevOps projects"
 - "Show me my active work items"
 - "Create a new bug titled 'Login page error' in the WebApp project"
@@ -263,11 +303,22 @@ Once configured, you can ask Claude:
 - "Update task 281 to Completed state"
 - "What bugs are assigned to me?"
 - "Show me work items that changed this week"
+
+**Sprint Management:**
 - "List all sprints in the WebApp project"
 - "What's in our current sprint?"
 - "Move task 123 to the next sprint"
 - "Show me all work items in Sprint 5"
 - "Get details about Sprint 3"
+
+**Relationship Management:**
+- "Add work item 456 as a parent of task 123"
+- "Show all relationships for work item 789"
+- "Mark work item 101 as a duplicate of 102"
+- "Add task 234 as a predecessor to task 567"
+- "Remove the relationship between items 333 and 444"
+- "What work items are related to epic 100?"
+- "List all available relationship types"
 
 ## 🔧 Development
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,8 +1,8 @@
 {
   "name": "azure-devops-mcp",
   "title": "Azure DevOps MCP Server",
-  "description": "Seamlessly interact with Azure DevOps work items, projects, and boards through Claude. Create, update, and query work items using natural language.",
-  "version": "2.1.0",
+  "description": "Seamlessly interact with Azure DevOps work items, projects, iterations, and relationships through Claude. Create, update, query, and manage work item hierarchies using natural language.",
+  "version": "2.2.0",
   "author": {
     "name": "Jeremy Paxton",
     "email": "jeremy.paxton@jybrd.io",
@@ -61,6 +61,9 @@
     "Add comments and track discussions",
     "Smart query shortcuts for personal productivity",
     "Support for all work item types (Tasks, Bugs, User Stories, Features, Epics)",
+    "Sprint and iteration management",
+    "Work item relationship management (Parent/Child, Dependencies, Related)",
+    "Build complex work item hierarchies",
     "Automatic organization configuration"
   ],
   "tools": [
@@ -86,6 +89,71 @@
           "description": "Limit results to specific project"
         }
       ]
+    },
+    {
+      "name": "add_work_item_relation",
+      "description": "Add relationships between work items (Parent/Child, Related, Dependencies)",
+      "parameters": [
+        {
+          "name": "id",
+          "type": "number",
+          "required": true,
+          "description": "Source work item ID"
+        },
+        {
+          "name": "relation_type",
+          "type": "string",
+          "required": true,
+          "description": "Relationship type (Parent, Child, Related, Predecessor, Successor, Duplicate)"
+        },
+        {
+          "name": "target_id",
+          "type": "number or array",
+          "required": false,
+          "description": "Target work item ID(s)"
+        }
+      ]
+    },
+    {
+      "name": "remove_work_item_relation",
+      "description": "Remove relationships between work items",
+      "parameters": [
+        {
+          "name": "id",
+          "type": "number",
+          "required": true,
+          "description": "Source work item ID"
+        },
+        {
+          "name": "relation_type",
+          "type": "string",
+          "required": true,
+          "description": "Relationship type to remove"
+        },
+        {
+          "name": "target_id",
+          "type": "number or array",
+          "required": true,
+          "description": "Target work item ID(s) to unlink"
+        }
+      ]
+    },
+    {
+      "name": "get_work_item_relations",
+      "description": "Show all relationships for a work item with friendly categorization",
+      "parameters": [
+        {
+          "name": "id",
+          "type": "number",
+          "required": true,
+          "description": "Work item ID"
+        }
+      ]
+    },
+    {
+      "name": "list_relation_types",
+      "description": "List all available work item relation types in Azure DevOps",
+      "parameters": []
     },
     {
       "name": "get_work_item",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jybrd/azure-devops-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Model Context Protocol server for Azure DevOps integration - enables Claude to interact with work items, projects, and boards",
   "keywords": [
     "mcp",

--- a/src/handlers/relations.ts
+++ b/src/handlers/relations.ts
@@ -1,0 +1,335 @@
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { ensureOrgConfigured } from '../helpers/ensureOrg.js';
+import { HandlerResult } from '../types.js';
+import type { 
+    AddWorkItemRelationArgs, 
+    RemoveWorkItemRelationArgs, 
+    GetWorkItemRelationsArgs,
+    ListRelationTypesArgs
+} from '../types/relations.js';
+
+const execAsync = promisify(exec);
+
+/**
+ * Map user-friendly relation types to Azure DevOps relation types
+ */
+const RELATION_TYPE_MAP: Record<string, string> = {
+    // Hierarchy
+    'parent': 'System.LinkTypes.Hierarchy-Reverse',
+    'child': 'System.LinkTypes.Hierarchy-Forward',
+    
+    // Related
+    'related': 'System.LinkTypes.Related',
+    
+    // Dependency
+    'predecessor': 'System.LinkTypes.Dependency-Reverse',
+    'successor': 'System.LinkTypes.Dependency-Forward',
+    
+    // Duplicate
+    'duplicate': 'System.LinkTypes.Duplicate-Forward',
+    'duplicate of': 'System.LinkTypes.Duplicate-Reverse',
+    
+    // Testing
+    'tested by': 'Microsoft.VSTS.Common.TestedBy-Forward',
+    'tests': 'Microsoft.VSTS.Common.TestedBy-Reverse',
+    
+    // Keep original if not mapped
+};
+
+/**
+ * Normalize relation type to Azure DevOps format
+ * Azure CLI expects the friendly names, not the full reference names
+ */
+function normalizeRelationType(type: string): string {
+    // Azure CLI accepts friendly names directly
+    // Just ensure consistent casing
+    return type;
+}
+
+/**
+ * Format target IDs for CLI command
+ */
+function formatTargetIds(targetId: number | number[] | undefined): string[] {
+    if (!targetId) return [];
+    return Array.isArray(targetId) ? targetId.map(id => id.toString()) : [targetId.toString()];
+}
+
+export async function handleAddWorkItemRelation(args: AddWorkItemRelationArgs): Promise<HandlerResult> {
+    await ensureOrgConfigured();
+    
+    const relationType = normalizeRelationType(args.relation_type);
+    let command = `az boards work-item relation add --id ${args.id} --relation-type "${relationType}"`;
+    
+    // Handle target specification
+    if (args.target_id) {
+        const targetIds = formatTargetIds(args.target_id);
+        if (targetIds.length > 0) {
+            command += ` --target-id ${targetIds.join(' ')}`;
+        }
+    } else if (args.target_url) {
+        command += ` --target-url "${args.target_url}"`;
+    } else {
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    error: 'Either target_id or target_url must be provided'
+                }, null, 2),
+            }],
+            isError: true,
+        };
+    }
+    
+    command += ' --output json';
+    
+    try {
+        const { stdout } = await execAsync(command);
+        const result = JSON.parse(stdout);
+        
+        // Extract relation information
+        const relations = result.relations || [];
+        const newRelations = relations.filter((rel: any) => 
+            rel.rel === relationType
+        );
+        
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    message: `Added ${args.relation_type} relationship to work item #${args.id}`,
+                    workItemId: args.id,
+                    relationType: args.relation_type,
+                    targetIds: args.target_id,
+                    newRelations: newRelations.map((rel: any) => ({
+                        type: rel.rel,
+                        url: rel.url,
+                        targetId: rel.url ? parseInt(rel.url.split('/').pop() || '0') : null
+                    })),
+                    totalRelations: relations.length
+                }, null, 2),
+            }],
+        };
+    } catch (error: any) {
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    error: `Failed to add relation: ${error.message}`,
+                    hint: 'Ensure both work items exist and you have permission to modify them'
+                }, null, 2),
+            }],
+            isError: true,
+        };
+    }
+}
+
+export async function handleRemoveWorkItemRelation(args: RemoveWorkItemRelationArgs): Promise<HandlerResult> {
+    await ensureOrgConfigured();
+    
+    const relationType = normalizeRelationType(args.relation_type);
+    const targetIds = formatTargetIds(args.target_id);
+    
+    if (targetIds.length === 0) {
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    error: 'No target IDs provided'
+                }, null, 2),
+            }],
+            isError: true,
+        };
+    }
+    
+    let command = `az boards work-item relation remove --id ${args.id} --relation-type "${relationType}" --target-id ${targetIds.join(' ')} --yes --output json`;
+    
+    try {
+        const { stdout } = await execAsync(command);
+        const result = JSON.parse(stdout);
+        
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    message: `Removed ${args.relation_type} relationship from work item #${args.id}`,
+                    workItemId: args.id,
+                    relationType: args.relation_type,
+                    removedTargetIds: args.target_id,
+                    remainingRelations: result.relations?.length || 0
+                }, null, 2),
+            }],
+        };
+    } catch (error: any) {
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    error: `Failed to remove relation: ${error.message}`,
+                    hint: 'Ensure the relation exists and you have permission to modify it'
+                }, null, 2),
+            }],
+            isError: true,
+        };
+    }
+}
+
+export async function handleGetWorkItemRelations(args: GetWorkItemRelationsArgs): Promise<HandlerResult> {
+    await ensureOrgConfigured();
+    
+    const command = `az boards work-item relation show --id ${args.id} --output json`;
+    
+    try {
+        const { stdout } = await execAsync(command);
+        const result = JSON.parse(stdout);
+        
+        // Group relations by type for better readability
+        const groupedRelations: Record<string, any[]> = {};
+        const relations = result.relations || [];
+        
+        relations.forEach((rel: any) => {
+            const type = rel.rel || 'Unknown';
+            if (!groupedRelations[type]) {
+                groupedRelations[type] = [];
+            }
+            
+            // Extract target ID from URL
+            const targetId = rel.url ? rel.url.split('/').pop() : null;
+            
+            groupedRelations[type].push({
+                targetId: targetId ? parseInt(targetId) : null,
+                url: rel.url,
+                attributes: rel.attributes
+            });
+        });
+        
+        // Create friendly names mapping
+        const friendlyNames: Record<string, string> = {
+            'System.LinkTypes.Hierarchy-Forward': 'Children',
+            'System.LinkTypes.Hierarchy-Reverse': 'Parent',
+            'System.LinkTypes.Related': 'Related',
+            'System.LinkTypes.Dependency-Forward': 'Successors',
+            'System.LinkTypes.Dependency-Reverse': 'Predecessors',
+            'System.LinkTypes.Duplicate-Forward': 'Duplicates',
+            'System.LinkTypes.Duplicate-Reverse': 'Duplicate Of',
+            'Microsoft.VSTS.Common.TestedBy-Forward': 'Tested By',
+            'Microsoft.VSTS.Common.TestedBy-Reverse': 'Tests',
+        };
+        
+        // Transform to friendly format
+        const friendlyRelations: Record<string, any[]> = {};
+        Object.entries(groupedRelations).forEach(([type, items]) => {
+            const friendlyName = friendlyNames[type] || type;
+            friendlyRelations[friendlyName] = items;
+        });
+        
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    workItemId: args.id,
+                    totalRelations: relations.length,
+                    relationsByType: friendlyRelations,
+                    summary: {
+                        parents: groupedRelations['System.LinkTypes.Hierarchy-Reverse']?.length || 0,
+                        children: groupedRelations['System.LinkTypes.Hierarchy-Forward']?.length || 0,
+                        related: groupedRelations['System.LinkTypes.Related']?.length || 0,
+                        predecessors: groupedRelations['System.LinkTypes.Dependency-Reverse']?.length || 0,
+                        successors: groupedRelations['System.LinkTypes.Dependency-Forward']?.length || 0,
+                        duplicates: groupedRelations['System.LinkTypes.Duplicate-Forward']?.length || 0,
+                    }
+                }, null, 2),
+            }],
+        };
+    } catch (error: any) {
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    error: `Failed to get relations: ${error.message}`,
+                    hint: 'Ensure the work item exists and you have permission to view it'
+                }, null, 2),
+            }],
+            isError: true,
+        };
+    }
+}
+
+export async function handleListRelationTypes(args: ListRelationTypesArgs): Promise<HandlerResult> {
+    await ensureOrgConfigured();
+    
+    const command = `az boards work-item relation list-type --output json`;
+    
+    try {
+        const { stdout } = await execAsync(command);
+        const relationTypes = JSON.parse(stdout);
+        
+        // Group by category for better organization
+        const categorized = {
+            hierarchy: [] as any[],
+            dependency: [] as any[],
+            related: [] as any[],
+            testing: [] as any[],
+            other: [] as any[]
+        };
+        
+        relationTypes.forEach((type: any) => {
+            const simplified = {
+                name: type.name,
+                referenceName: type.referenceName,
+                usage: type.attributes?.usage,
+                directional: type.attributes?.directional,
+                editable: type.attributes?.editable
+            };
+            
+            if (type.referenceName?.includes('Hierarchy')) {
+                categorized.hierarchy.push(simplified);
+            } else if (type.referenceName?.includes('Dependency')) {
+                categorized.dependency.push(simplified);
+            } else if (type.referenceName?.includes('Related')) {
+                categorized.related.push(simplified);
+            } else if (type.referenceName?.includes('Test')) {
+                categorized.testing.push(simplified);
+            } else {
+                categorized.other.push(simplified);
+            }
+        });
+        
+        // Common usage examples
+        const usageExamples = {
+            "Parent/Child": "Use 'Parent' or 'Child' in add_work_item_relation",
+            "Related": "Use 'Related' for bidirectional relationships",
+            "Dependencies": "Use 'Predecessor' or 'Successor' for task dependencies",
+            "Duplicates": "Use 'Duplicate' or 'Duplicate Of' to mark duplicates",
+            "Testing": "Use 'Tested By' or 'Tests' for test relationships"
+        };
+        
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    totalTypes: relationTypes.length,
+                    categorizedTypes: categorized,
+                    usageExamples: usageExamples,
+                    hint: "You can use friendly names like 'Parent', 'Child', 'Related' etc. when adding relations"
+                }, null, 2),
+            }],
+        };
+    } catch (error: any) {
+        return {
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    error: `Failed to list relation types: ${error.message}`,
+                    defaultTypes: {
+                        hierarchy: ['Parent', 'Child'],
+                        related: ['Related'],
+                        dependency: ['Predecessor', 'Successor'],
+                        duplicate: ['Duplicate', 'Duplicate Of'],
+                        testing: ['Tested By', 'Tests']
+                    }
+                }, null, 2),
+            }],
+        };
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,13 @@ import * as workItemHandlers from './handlers/workitems.js';
 import * as discoveryHandlers from './handlers/discovery.js';
 import * as projectHandlers from './handlers/projects.js';
 import * as iterationHandlers from './handlers/iterations.js';
+import * as relationHandlers from './handlers/relations.js';
 
 // Create server
 const server = new Server(
     {
         name: 'azure-devops-mcp',
-        version: '2.1.0',
+        version: '2.2.0',
     },
     {
         capabilities: {
@@ -24,7 +25,7 @@ const server = new Server(
     }
 );
 
-// Register all 26 tools using the modular definitions
+// Register all 30 tools using the modular definitions
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: allTools,
 }));
@@ -119,8 +120,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 result = await projectHandlers.handleGetProjectStats(args);
                 break;
 
-            // Query Operations removed - 5 tools removed
-
             // Iteration Operations (5 tools)
             case 'list_iterations':
                 result = await iterationHandlers.listIterations(args as any);
@@ -163,6 +162,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     }],
                 };
 
+            // Relation Operations (4 tools) - NEW!
+            case 'add_work_item_relation':
+                result = await relationHandlers.handleAddWorkItemRelation(args as any);
+                break;
+            case 'remove_work_item_relation':
+                result = await relationHandlers.handleRemoveWorkItemRelation(args as any);
+                break;
+            case 'get_work_item_relations':
+                result = await relationHandlers.handleGetWorkItemRelations(args as any);
+                break;
+            case 'list_relation_types':
+                result = await relationHandlers.handleListRelationTypes(args as any);
+                break;
+
             default:
                 throw new Error(`Unknown tool: ${name}`);
         }
@@ -199,7 +212,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error('Azure DevOps MCP Server v2.1.0 running with 26 tools enabled...');
+    console.error('Azure DevOps MCP Server v2.2.0 running with 30 tools enabled...');
 }
 
 main().catch(console.error);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,11 +3,13 @@ import { workItemTools } from './workitems.js';
 import { discoveryTools } from './discovery.js';
 import { projectTools } from './projects.js';
 import { iterationTools } from './iterations.js';
+import { relationTools } from './relations.js';
 
-// Combine all tools (26 total) - Query tools removed
+// Combine all tools (30 total)
 export const allTools: ToolDefinition[] = [
     ...workItemTools,    // 6 tools
     ...discoveryTools,   // 9 tools
     ...projectTools,     // 6 tools
     ...iterationTools,   // 5 tools
+    ...relationTools,    // 4 tools - NEW!
 ];

--- a/src/tools/relations.ts
+++ b/src/tools/relations.ts
@@ -1,0 +1,80 @@
+import { ToolDefinition } from '../types.js';
+
+export const relationTools: ToolDefinition[] = [
+    {
+        name: 'add_work_item_relation',
+        description: 'Add a relationship between work items',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { 
+                    type: 'number', 
+                    description: 'Source work item ID' 
+                },
+                relation_type: { 
+                    type: 'string', 
+                    description: 'Relation type (e.g., "Parent", "Child", "Related", "Predecessor", "Successor", "Duplicate")' 
+                },
+                target_id: { 
+                    oneOf: [
+                        { type: 'number' },
+                        { type: 'array', items: { type: 'number' } }
+                    ],
+                    description: 'Target work item ID(s) (optional if target_url is provided)' 
+                },
+                target_url: { 
+                    type: 'string', 
+                    description: 'URL to target work item (optional if target_id is provided)' 
+                }
+            },
+            required: ['id', 'relation_type'],
+        },
+    },
+    {
+        name: 'remove_work_item_relation',
+        description: 'Remove a relationship between work items',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { 
+                    type: 'number', 
+                    description: 'Source work item ID' 
+                },
+                relation_type: { 
+                    type: 'string', 
+                    description: 'Relation type to remove' 
+                },
+                target_id: { 
+                    oneOf: [
+                        { type: 'number' },
+                        { type: 'array', items: { type: 'number' } }
+                    ],
+                    description: 'Target work item ID(s) to unlink' 
+                }
+            },
+            required: ['id', 'relation_type', 'target_id'],
+        },
+    },
+    {
+        name: 'get_work_item_relations',
+        description: 'Show all relationships for a work item',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { 
+                    type: 'number', 
+                    description: 'Work item ID' 
+                }
+            },
+            required: ['id'],
+        },
+    },
+    {
+        name: 'list_relation_types',
+        description: 'List all available work item relation types',
+        inputSchema: {
+            type: 'object',
+            properties: {},
+        },
+    },
+];

--- a/src/types/relations.ts
+++ b/src/types/relations.ts
@@ -1,0 +1,51 @@
+/**
+ * Type definitions for work item relationship management
+ */
+
+export interface AddWorkItemRelationArgs {
+    id: number;
+    relation_type: string;
+    target_id?: number | number[];
+    target_url?: string;
+}
+
+export interface RemoveWorkItemRelationArgs {
+    id: number;
+    relation_type: string;
+    target_id: number | number[];
+}
+
+export interface GetWorkItemRelationsArgs {
+    id: number;
+}
+
+export interface ListRelationTypesArgs {
+    // No parameters needed
+}
+
+export interface WorkItemRelation {
+    rel: string;
+    url: string;
+    attributes?: {
+        isLocked?: boolean;
+        authorizedDate?: string;
+        id?: number;
+        resourceCreatedDate?: string;
+        resourceModifiedDate?: string;
+        revisedDate?: string;
+    };
+}
+
+export interface RelationType {
+    referenceName: string;
+    name: string;
+    attributes: {
+        usage: string;
+        editable: boolean;
+        enabled: boolean;
+        acyclic: boolean;
+        directional: boolean;
+        singleTarget: boolean;
+        topology: string;
+    };
+}

--- a/test-compile.sh
+++ b/test-compile.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Test script to validate TypeScript compilation for the new relation tools
+# Run this in your project directory: bash test-compile.sh
+
+echo "🔍 Testing Azure DevOps MCP Server v2.2.0 Compilation"
+echo "=================================================="
+echo ""
+
+# Check if we're in the right directory
+if [ ! -f "package.json" ]; then
+    echo "❌ Error: Not in the azure-devops-mcp project directory"
+    echo "   Please run this script from the project root"
+    exit 1
+fi
+
+# Check if dependencies are installed
+if [ ! -d "node_modules" ]; then
+    echo "📦 Installing dependencies..."
+    npm install
+fi
+
+# Clean previous build
+echo "🧹 Cleaning previous build..."
+rm -rf dist/
+
+# Run TypeScript compilation
+echo "🔨 Compiling TypeScript..."
+npx tsc
+
+# Check if compilation was successful
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ Compilation successful!"
+    echo ""
+    
+    # Check that all new files were created
+    echo "📋 Checking new relation files..."
+    
+    if [ -f "dist/types/relations.js" ]; then
+        echo "  ✓ dist/types/relations.js created"
+    else
+        echo "  ✗ dist/types/relations.js missing"
+    fi
+    
+    if [ -f "dist/tools/relations.js" ]; then
+        echo "  ✓ dist/tools/relations.js created"
+    else
+        echo "  ✗ dist/tools/relations.js missing"
+    fi
+    
+    if [ -f "dist/handlers/relations.js" ]; then
+        echo "  ✓ dist/handlers/relations.js created"
+    else
+        echo "  ✗ dist/handlers/relations.js missing"
+    fi
+    
+    echo ""
+    echo "🎉 Azure DevOps MCP Server v2.2.0 is ready!"
+    echo "   Total tools: 30 (including 4 new relationship management tools)"
+    echo ""
+    echo "New tools added:"
+    echo "  • add_work_item_relation"
+    echo "  • remove_work_item_relation"
+    echo "  • get_work_item_relations"
+    echo "  • list_relation_types"
+else
+    echo ""
+    echo "❌ Compilation failed!"
+    echo "   Please check the TypeScript errors above"
+    exit 1
+fi


### PR DESCRIPTION
Add 4 new tools for managing work item relationships (parent/child, dependencies, related, duplicates). Enables building complex work item hierarchies and tracking dependencies. Includes fix for Azure CLI relation type compatibility.

Tools added: add_work_item_relation, remove_work_item_relation, get_work_item_relations, list_relation_types

Docs: Updated CHANGELOG, EXAMPLES, and mcp.json